### PR TITLE
feat(forms-go): implement new forms-go page with prefill support, add…

### DIFF
--- a/src/app/forms-go/[slug]/page.tsx
+++ b/src/app/forms-go/[slug]/page.tsx
@@ -1,0 +1,69 @@
+// src/app/forms-go/[slug]/page.tsx
+import { notFound } from "next/navigation";
+import { getFormBySlug } from "@/lib/formsRegistry";
+import LeadForm from "@/components/LeadForm";
+import { prefillFromSearchParams } from "@/lib/prefill";
+
+type Props = {
+  params: { slug: string };
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+export default async function Page({ params, searchParams }: Props) {
+  const form = await getFormBySlug(params.slug);
+  if (!form) return notFound();
+
+  // Prefill from query
+  const sp = new URLSearchParams(
+    Object.entries(searchParams).flatMap(([k, v]) =>
+      Array.isArray(v) ? v.map((x) => [k, x]) : v ? [[k, v]] : []
+    ) as [string, string][]
+  );
+  const prefill = prefillFromSearchParams(sp);
+
+  // Compose tags to mark the source
+  const tagsOnSubmit = [
+    "form-go",
+    "ghl-native-calendar",
+    `slug:${params.slug}`,
+  ];
+
+  // Hidden meta we might want to persist (optional)
+  const hiddenMeta = {
+    appointmentId: prefill.appointmentId,
+    appointmentTime: prefill.appointmentTime,
+    calendarId: prefill.calendarId,
+    source: "ghl_native_redirect",
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-2xl bg-white rounded-xl border shadow-sm p-6 sm:p-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold">
+            {form.name || params.slug.replace(/-/g, " ")}
+          </h1>
+          <p className="text-sm text-gray-500">Complete your details below.</p>
+        </div>
+
+        <LeadForm
+          formSlug={params.slug}
+          formConfig={form}
+          legal={form.legal}
+          // IMPORTANT: this route does NOT render the calendar step
+          // We simply render the lead form directly.
+          initialValues={{
+            firstName: prefill.firstName,
+            lastName: prefill.lastName,
+            email: prefill.email,
+            phone: prefill.phone,
+            country: prefill.country,
+            note: prefill.note,
+          }}
+          tagsOnSubmit={tagsOnSubmit}
+          hiddenMeta={hiddenMeta}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/forms/[slug]/page.tsx
+++ b/src/app/forms/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import LeadForm from "@/components/LeadForm";
 import BookingWizard from "@/components/BookingWizard";
 import { getFormBySlug } from "@/lib/formsRegistry";
-import { parsePrefillFromSearchParams } from "@/lib/prefill";
+import { prefillFromSearchParams } from "@/lib/prefill";
 import Image from "next/image";
 
 export const dynamic = "force-dynamic";
@@ -24,7 +24,7 @@ export default async function Page({
       Array.isArray(v) ? v.map((vv) => [k, vv]) : v ? [[k, v]] : []
     ) as [string, string][]
   );
-  const prefill = parsePrefillFromSearchParams(sp);
+  const prefill = prefillFromSearchParams(sp);
 
   const form = getFormBySlug(slug);
 

--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -200,6 +200,9 @@ export default function LeadForm({
   isBookingWizard = false,
   selectedSlotISO,
   timezone,
+  initialValues,
+  tagsOnSubmit,
+  hiddenMeta,
 }: {
   formSlug: string;
   formConfig: FormConfig;
@@ -211,11 +214,29 @@ export default function LeadForm({
   isBookingWizard?: boolean;
   selectedSlotISO?: string | null;
   timezone?: string;
+  initialValues?: Partial<{
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    country: string;
+    note: string;
+  }>;
+  tagsOnSubmit?: string[];
+  hiddenMeta?: Record<string, string | undefined>;
 }) {
-  const [firstName, setFirstName] = useState(prefill?.firstName ?? "");
-  const [lastName, setLastName] = useState(prefill?.lastName ?? "");
-  const [email, setEmail] = useState(prefill?.email ?? "");
-  const [phone, setPhone] = useState(prefill?.phone ?? "");
+  const [firstName, setFirstName] = useState(
+    initialValues?.firstName ?? prefill?.firstName ?? ""
+  );
+  const [lastName, setLastName] = useState(
+    initialValues?.lastName ?? prefill?.lastName ?? ""
+  );
+  const [email, setEmail] = useState(
+    initialValues?.email ?? prefill?.email ?? ""
+  );
+  const [phone, setPhone] = useState(
+    initialValues?.phone ?? prefill?.phone ?? ""
+  );
   const [consentTransactional, setConsentTransactional] = useState(false);
   const [consentMarketing, setConsentMarketing] = useState(false);
 
@@ -262,11 +283,26 @@ export default function LeadForm({
   const [emailAttempted, setEmailAttempted] = useState(false);
   const [phoneAttempted, setPhoneAttempted] = useState(false);
 
-  const [country, setCountry] = useState<string>(prefill?.country || "US");
+  const [country, setCountry] = useState<string>(
+    initialValues?.country ?? (prefill?.country || "US")
+  );
 
   // Dynamic registry-driven answers
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [dynErrors, setDynErrors] = useState<Record<string, string>>({});
+
+  // Handle initial values updates
+  useEffect(() => {
+    if (!initialValues) return;
+    if (initialValues.firstName !== undefined)
+      setFirstName(initialValues.firstName);
+    if (initialValues.lastName !== undefined)
+      setLastName(initialValues.lastName);
+    if (initialValues.email !== undefined) setEmail(initialValues.email);
+    if (initialValues.phone !== undefined) setPhone(initialValues.phone);
+    if (initialValues.country !== undefined) setCountry(initialValues.country);
+    // Note: note field not currently implemented in the form
+  }, [initialValues]);
 
   // (debug removed)
 
@@ -547,9 +583,13 @@ export default function LeadForm({
               consentMarketing,
               answers, // Send dynamic form answers
               // Include calendar/appointment meta if present
-              ...(prefill?.calendar && { calendar: prefill.calendar }),
-              ...(prefill?.apptStart && { apptStart: prefill.apptStart }),
-              ...(prefill?.apptTz && { apptTz: prefill.apptTz }),
+              ...(prefill?.calendarId && { calendarId: prefill.calendarId }),
+              ...(prefill?.appointmentTime && {
+                appointmentTime: prefill.appointmentTime,
+              }),
+              // Include additional tags and meta for forms-go
+              ...(tagsOnSubmit && { tags: tagsOnSubmit }),
+              ...(hiddenMeta && { meta: hiddenMeta }),
             };
 
         const res = await fetch(apiEndpoint, {

--- a/src/lib/prefill.ts
+++ b/src/lib/prefill.ts
@@ -3,39 +3,36 @@ export type Prefill = {
   firstName?: string;
   lastName?: string;
   email?: string;
-  phone?: string; // national format (no +country)
-  country?: "US" | "CA" | string;
-  calendar?: string;
-  apptStart?: string;
-  apptTz?: string;
+  phone?: string;
+  country?: string;
+  note?: string;
+
+  // Optional booking context we may want to stash as custom fields/tags
+  appointmentId?: string;
+  appointmentTime?: string; // ISO
+  calendarId?: string;
 };
 
-export function parsePrefillFromSearchParams(sp: URLSearchParams): Prefill {
-  const t = (s?: string | null) => (s ?? "").trim() || undefined;
-
-  let country = t(sp.get("country"))?.toUpperCase();
-  if (country && country.length > 2) {
-    // Normalize common country names to ISO2 if GHL sends full names
-    if (country.includes("UNITED STATES")) country = "US";
-    if (country.includes("UNITED STATES OF AMERICA")) country = "US";
-    if (country.includes("CANADA")) country = "CA";
+const val = (sp: URLSearchParams, ...keys: string[]) => {
+  for (const k of keys) {
+    const v = sp.get(k);
+    if (v && v.trim()) return v.trim();
   }
+  return undefined;
+};
 
-  // Strip everything except digits; trim leading 1 for NANP countries
-  const rawPhone = t(sp.get("phone"))?.replace(/[^\d]/g, "");
-  let phone = rawPhone;
-  if (phone && (country === "US" || country === "CA")) {
-    if (phone.length === 11 && phone.startsWith("1")) phone = phone.slice(1);
-  }
-
+export function prefillFromSearchParams(sp: URLSearchParams): Prefill {
   return {
-    firstName: t(sp.get("firstName")),
-    lastName: t(sp.get("lastName")),
-    email: t(sp.get("email")),
-    phone,
-    country,
-    calendar: t(sp.get("calendar")),
-    apptStart: t(sp.get("apptStart")),
-    apptTz: t(sp.get("apptTz")),
+    firstName: val(sp, "firstName", "fname", "first_name"),
+    lastName: val(sp, "lastName", "lname", "last_name"),
+    email: val(sp, "email"),
+    phone: val(sp, "phone", "phone_number"),
+    country: val(sp, "country", "countryCode"),
+
+    note: val(sp, "note"),
+
+    appointmentId: val(sp, "appointmentId", "apptId"),
+    appointmentTime: val(sp, "appointmentTime", "startTime"),
+    calendarId: val(sp, "calendarId"),
   };
 }


### PR DESCRIPTION
This pull request introduces support for the new "forms-go" flow, improving how lead forms are prefilled and submitted, and adding flexibility for passing tags and hidden metadata. The changes include a new route for forms-go, enhanced prefill logic, and updates to the lead form and API to handle additional data.

**Support for forms-go flow and enhanced data handling:**

* Added a new route `src/app/forms-go/[slug]/page.tsx` to support forms-go forms, which pre-fills lead data from search parameters and submits additional tags and hidden meta information. ([src/app/forms-go/[slug]/page.tsxR1-R69](diffhunk://#diff-4b65756b271dab3ee5afc949ed56946551c0fb6fe8a34a6a4d3860c5c4423ed7R1-R69))
* Updated the `LeadForm` component to accept and use `initialValues`, `tagsOnSubmit`, and `hiddenMeta` for more flexible form initialization and submission. [[1]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R203-R205) [[2]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R217-R239) [[3]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L265-R306) [[4]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L550-R592)

**Prefill logic improvements:**

* Refactored the prefill logic in `src/lib/prefill.ts` to a new `prefillFromSearchParams` function, which supports multiple key aliases and additional fields like `note`, `appointmentId`, and `appointmentTime`.
* Updated usages of prefill logic in the forms routes to use the new `prefillFromSearchParams` function. ([src/app/forms/[slug]/page.tsxL5-R5](diffhunk://#diff-68edbc2e6528af3d52ce14b3a05dccd14a7768636018a1d11ed4cf863b25a4f6L5-R5), [src/app/forms/[slug]/page.tsxL27-R27](diffhunk://#diff-68edbc2e6528af3d52ce14b3a05dccd14a7768636018a1d11ed4cf863b25a4f6L27-R27))

**API enhancements:**

* Modified the lead API payload in `src/app/api/lead/route.ts` to accept `tags` and `meta` fields, and updated submission logic to store meta data in custom fields when available and merge tags from forms-go. [[1]](diffhunk://#diff-0088b4e1c1844d576b5e1a170d1b5d08ac5d91acc0cf41a72c3b428dc47f9552R28-R29) [[2]](diffhunk://#diff-0088b4e1c1844d576b5e1a170d1b5d08ac5d91acc0cf41a72c3b428dc47f9552R109-R138)