### PR TITLE
Rn/dev

### DIFF
--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,47 @@
+// src/lib/phone.ts
+const COUNTRY_TO_CC: Record<string, string> = {
+  US: "1",
+  CA: "1",
+  GB: "44",
+  AU: "61",
+  // extend as needed
+};
+
+export function onlyDigits(s: string | undefined): string {
+  return (s || "").replace(/\D+/g, "");
+}
+
+/**
+ * Convert a possibly E.164 string (+1305...), or raw ("1305..."), to national digits
+ * given an ISO country (US, CA, GB...). For NANP (US/CA), strip leading '1' if present.
+ */
+export function toNationalDigits(
+  input: string | undefined,
+  country?: string
+): string {
+  const digits = onlyDigits(input);
+  if (!digits) return "";
+
+  const cc = COUNTRY_TO_CC[(country || "").toUpperCase()];
+  if (!cc) return digits; // Unknown country → show raw digits
+
+  // If starts with country calling code, strip it.
+  if (digits.startsWith(cc)) {
+    return digits.slice(cc.length);
+  }
+  return digits;
+}
+
+/**
+ * Build E.164 string from national digits + country. Returns "+<cc><national>" or "".
+ */
+export function toE164(
+  nationalDigits: string | undefined,
+  country?: string
+): string {
+  const nd = onlyDigits(nationalDigits);
+  if (!nd) return "";
+  const cc = COUNTRY_TO_CC[(country || "").toUpperCase()];
+  if (!cc) return ""; // Unknown country → let validator fail gracefully
+  return `+${cc}${nd}`;
+}


### PR DESCRIPTION
This pull request refactors phone number handling and validation in the `LeadForm` component to improve consistency and reliability, especially for international formats. It introduces utility functions for digit extraction and E.164 formatting, updates how phone numbers are processed on input and submission, and adds more robust prefill validation logic.

**Phone number normalization and validation improvements:**

* Added new utility functions `onlyDigits`, `toNationalDigits`, and `toE164` in `src/lib/phone.ts` to standardize phone number formatting and conversion for different countries. (`[src/lib/phone.tsR1-R47](diffhunk://#diff-da2e667f4ecb512f586d41b343ffc91a80271a74d06f75baf880d542cada0a75R1-R47)`)
* Updated phone input handling in `LeadForm.tsx` to use `onlyDigits` for UI display and `toE164` for validation, ensuring consistent digit extraction and correct international format validation. (`[src/components/LeadForm.tsxL497-R545](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L497-R545)`)
* When initializing the form with prefilled values, phone numbers are now converted to national digits using `toNationalDigits`, improving display accuracy for different countries. (`[src/components/LeadForm.tsxL302-R308](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L302-R308)`)

**Prefill and auto-validation enhancements:**

* Refactored the prefill auto-validation logic to run validation only once per mount, using both initial and prefill values, and made it configurable via a new `prefillValidate` prop. (`[[1]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R207)`, `[[2]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R229)`, `[[3]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L497-R545)`)
* Improved the validation trigger for country changes to always use E.164 format when possible, ensuring correct validation for international numbers. (`[src/components/LeadForm.tsxL497-R545](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L497-R545)`)

**Submission logic updates:**

* Updated form submission to send phone numbers in E.164 format when possible, falling back to raw digits if conversion fails, for both lead creation and consent submission. (`[[1]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L563-R580)`, `[[2]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668L580-R597)`)