### PR TITLE
feat(email-block): implement email prefix blocking functionality; add…

### DIFF
--- a/src/app/api/validate/route.ts
+++ b/src/app/api/validate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { validateEmail, validatePhone } from "@/lib/validate";
+import { isBlockedEmailPrefix } from "@/lib/emailBlock";
 import { rateLimit } from "@/lib/rateLimit";
 
 export const runtime = "nodejs";
@@ -24,13 +25,22 @@ export async function POST(req: Request) {
 
     let emailResp = undefined;
     if (typeof email === "string") {
-      const r = await validateEmail(email);
-      emailResp = {
-        emailValid: r.valid,
-        emailReason: r.reason,
-        emailConfidence: r.confidence,
-        echoEmail: email,
-      };
+      const block = isBlockedEmailPrefix(email);
+      if (block.blocked) {
+        emailResp = {
+          emailValid: false,
+          emailReason: "This email address isn’t accepted.",
+          echoEmail: email,
+        };
+      } else {
+        const r = await validateEmail(email);
+        emailResp = {
+          emailValid: r.valid,
+          emailReason: r.reason,
+          emailConfidence: r.confidence,
+          echoEmail: email,
+        };
+      }
     }
 
     let phoneResp = undefined;

--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -11,6 +11,7 @@ import dynamic from "next/dynamic";
 import type { FormConfig } from "@/lib/formsRegistry";
 import type { Prefill } from "@/lib/prefill";
 import { toNationalDigits, toE164, onlyDigits } from "@/lib/phone";
+import { isBlockedEmailPrefix } from "@/lib/emailBlock";
 import { isRecaptchaRequiredForSlug, getRecaptchaSiteKey } from "@/lib/env";
 
 const ReCAPTCHA = dynamic(() => import("react-google-recaptcha"), {
@@ -428,6 +429,13 @@ export default function LeadForm({
     setEmailAttempted(true);
     setEmailPending(true);
     try {
+      // local short-circuit for blocked prefixes
+      const block = isBlockedEmailPrefix(value);
+      if (block.blocked) {
+        setEmailValid(false);
+        setEmailReason("This email address isn’t accepted.");
+        return;
+      }
       const res = await fetch("/api/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/lib/emailBlock.ts
+++ b/src/lib/emailBlock.ts
@@ -1,0 +1,17 @@
+export const BLOCKED_EMAIL_PREFIXES = ["motivation.usa"]; // case-insensitive
+
+export type BlockCheck = { blocked: boolean; reason?: string };
+
+export function isBlockedEmailPrefix(email?: string): BlockCheck {
+  if (!email) return { blocked: false };
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.indexOf("@");
+  if (at <= 0) return { blocked: false }; // let normal validators catch bad format
+  const local = trimmed.slice(0, at);
+  const blocked = BLOCKED_EMAIL_PREFIXES.some((p) =>
+    local.startsWith(p.toLowerCase())
+  );
+  return blocked
+    ? { blocked: true, reason: "blocked_prefix" }
+    : { blocked: false };
+}


### PR DESCRIPTION
This pull request introduces a new mechanism to block email addresses with certain prefixes across both backend and frontend validation processes. The main goal is to prevent submissions from emails with disallowed prefixes, improving data quality and compliance. The implementation is consistent across API endpoints and the user-facing form.

**Blocked Email Prefix Support**

* Added a new utility in `src/lib/emailBlock.ts` to define and check for blocked email prefixes, currently blocking emails starting with `"motivation.usa"`.
* Integrated the blocked prefix check into the lead submission API (`src/app/api/lead/route.ts`), returning an error response if a blocked prefix is detected before further validation [[1]](diffhunk://#diff-0088b4e1c1844d576b5e1a170d1b5d08ac5d91acc0cf41a72c3b428dc47f9552R3) [[2]](diffhunk://#diff-0088b4e1c1844d576b5e1a170d1b5d08ac5d91acc0cf41a72c3b428dc47f9552R72-R84).
* Added the blocked prefix check to the email validation API (`src/app/api/validate/route.ts`), ensuring early rejection and consistent error messaging [[1]](diffhunk://#diff-de162eed092c404160f14790c10b83d7d87686767433c2582ff074b0f8651758R3) [[2]](diffhunk://#diff-de162eed092c404160f14790c10b83d7d87686767433c2582ff074b0f8651758R28-R35) [[3]](diffhunk://#diff-de162eed092c404160f14790c10b83d7d87686767433c2582ff074b0f8651758R44).
* Updated the frontend lead form (`src/components/LeadForm.tsx`) to perform a local blocked prefix check before making API calls, providing immediate feedback to users [[1]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R14) [[2]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R432-R438).