### PR TITLE
Rn/dev

### DIFF
--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -595,6 +595,24 @@ export default function LeadForm({
     [setLastPending, setLastValid, setLastReason, lastTouched]
   );
 
+  // --- auto-validate prefilled first name (from query params) ---
+  useEffect(() => {
+    const v = (firstName ?? "").trim();
+    if (v && !firstTouched) {
+      setFirstTouched(true);
+      validateFirst(v);
+    }
+  }, [firstName, firstTouched, validateFirst]);
+
+  // --- auto-validate prefilled last name (from query params) ---
+  useEffect(() => {
+    const v = (lastName ?? "").trim();
+    if (v && !lastTouched) {
+      setLastTouched(true);
+      validateLast(v);
+    }
+  }, [lastName, lastTouched, validateLast]);
+
   // ------------ onChange re-validate (debounced) ------------
   const onEmailChange = (v: string) => {
     setEmail(v);


### PR DESCRIPTION
This pull request improves the user experience and validation quality for name inputs in the lead form. It adds auto-validation for prefilled names and enhances the anti-gibberish checks for Latin-script names to better catch unnatural or keyboard-smashed entries.

**Form UX improvements:**

* Added auto-validation for prefilled first and last names when loaded from query parameters, ensuring users see immediate feedback if their name is pre-populated.

**Name validation enhancements:**

* Added new heuristics for detecting gibberish in Latin-script names:
  * Flags long runs of consonants (≥4 in names ≥6 chars) as unnatural. [[1]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R39-R82) [[2]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R180-R219)
  * Flags high density of rare letters (q, x, z, j, k, f, w) as likely keyboard smash. [[1]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R39-R82) [[2]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R180-R219)
  * Flags names where a single bigram (two-letter sequence) dominates, which is common in repetitive patterns. [[1]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R39-R82) [[2]](diffhunk://#diff-b648332626c158d51d200bb3e0727ae7df1e0ccfeef6d6064fda82d882694e34R180-R219)
* These checks are skipped for names with diacritics or separators to avoid false positives for legitimate international names.