### PR TITLE
Rn/dev

### DIFF
--- a/src/lib/emailBlocklist.ts
+++ b/src/lib/emailBlocklist.ts
@@ -14,6 +14,8 @@ export const BLOCKED_EMAIL_DOMAINS = new Set<string>([
   "rhyta.com",
   "armyspy.com",
   "tiffincrane.com",
+  "mv6.com",
+  "acmecorp.com",
 ]);
 
 export type BlockCheck = {


### PR DESCRIPTION
This pull request introduces improved validation for US and Canadian phone numbers, strengthens human name validation, and updates the email blocklist. The most notable changes are the addition of a client-side and server-side precheck for US/CA phone numbers to enforce North American Numbering Plan (NANP) rules before making external API calls, and enhancements to the human name validator to better catch unnatural or mistyped names.

**Phone number validation improvements:**

* Added `mustBeValidUSLength` and related helpers in `phonevalidator.ts` to perform strict client-side and server-side prechecks for US/CA phone numbers, enforcing NANP digit count and format before calling the external phone validation API. This reduces unnecessary API calls and improves user feedback. [[1]](diffhunk://#diff-387132810ecf3f02c16097431f99461f5add3a2a4eea412e05bd8cd82a85ce3aR4-R61) [[2]](diffhunk://#diff-387132810ecf3f02c16097431f99461f5add3a2a4eea412e05bd8cd82a85ce3aR139-R173) [[3]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R15) [[4]](diffhunk://#diff-6f721a3e9728a2c5c7dfe9e4abc1f7fdbcb364f158c7b821f62c45084cd6e668R503-R517)
* Updated the phone validation flow in `LeadForm.tsx` to use the new precheck, providing immediate feedback to users entering invalid US/CA phone numbers.

**Human name validation enhancements:**

* Improved the `validateHumanName` function to check for names with at least one vowel (including 'Y'), use only letter characters for length calculations, and lower the threshold for the vowel/consonant ratio sanity check, making the validator more robust against unnatural or mistyped names.

**Email blocklist updates:**

* Added `mv6.com` and `acmecorp.com` to the set of blocked email domains to prevent signups from these disposable or test domains.